### PR TITLE
Improve screenshot fallback logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 This repository includes a small CLI utility `screenshot_tool.py` that captures a screenshot of a selected window on Windows.
 
+The tool uses the Windows `PrintWindow` API when possible and automatically falls back to a regular screen capture if the result appears blank. This helps when capturing hardware-accelerated applications such as modern browsers.
+
 ### Usage
 
 1. Install dependencies:

--- a/screenshot_tool.py
+++ b/screenshot_tool.py
@@ -70,7 +70,9 @@ def screenshot_window(hwnd, path):
     mfc_dc.DeleteDC()
     win32gui.ReleaseDC(hwnd, hwnd_dc)
 
-    if result != 1:
+    # Fallback to a screen capture if PrintWindow failed or produced
+    # a completely black image (common for hardware-accelerated windows)
+    if result != 1 or image.getbbox() is None:
         image = ImageGrab.grab(bbox=(left, top, right, bottom))
 
     image.save(path)


### PR DESCRIPTION
## Summary
- fix `screenshot_window` to fallback to a screen capture if `PrintWindow` fails or returns a black image
- document fallback behavior in README

## Testing
- `python -m py_compile screenshot_tool.py`
